### PR TITLE
Check if `require` is present

### DIFF
--- a/assets/computercraft/lua/rom/autorun/require.lua
+++ b/assets/computercraft/lua/rom/autorun/require.lua
@@ -3,6 +3,11 @@
 -- License: MIT - http://opensource.org/licenses/MIT
 -- Filename: require.lua
 
+-- Check if require already exists
+if type(_G.require) == "function" and type(package) == "table" then
+	return nil
+end
+
 _G.package = {}
 
 _G.package.cpath = ""


### PR DESCRIPTION
This PR checks if `require` already exists, to avoid wasting computer resources if accidentally ran twice or if ran on a new version that has `require` (as new versions of CC do not persist changes to builtins, like `require` or `package`).